### PR TITLE
fix(secrets): triage secrets

### DIFF
--- a/sfdc_metadata/cred_scan_triage/triage.yaml
+++ b/sfdc_metadata/cred_scan_triage/triage.yaml
@@ -1,0 +1,9 @@
+clean: true
+mock_secret:
+- id: utam-js-recipes://README.md_ce4a4e2583530c9507ee303de950441d048fdb50
+  justification: example in documentation
+- id: utam-js-recipes://README.md_1e975b74469bdda630e07c4a3a61f28e512aba17
+  justification: example in documentation
+false_positive: []
+non_production_secret: []
+production_secret: []


### PR DESCRIPTION
Automated tooling has flagged the use of "PASSWORD=strongPassword" and
"PASSWORD=password" in the readme as a possible secret in this repo.

This metadata file triages it as a mock secret.