### PR TITLE
fix: remove useless imports

### DIFF
--- a/force-app/test/utilities/salesforce-test.js
+++ b/force-app/test/utilities/salesforce-test.js
@@ -6,7 +6,6 @@
  */
 
 import Login from 'salesforce-pageobjects/helpers/pageObjects/login';
-import ActionRenderer from 'salesforce-pageobjects';
 
 /**
  * Helper function used in crud tests to login in STMFA environment


### PR DESCRIPTION
This PR removes a useless imports that cause tests to fails as it's an invalid entry point for consuming the Salesforce page objects