### PR TITLE
fix: typo in method name

### DIFF
--- a/wdioJasmineHelper.js
+++ b/wdioJasmineHelper.js
@@ -17,6 +17,6 @@ const DEFAULT_OPTIONS = {
 
 require('@babel/register')(DEFAULT_OPTIONS);
 
-module.exports = function _jasminRegister() {
+module.exports = function _jasmineRegister() {
     require('@babel/register')(DEFAULT_OPTIONS);
 };


### PR DESCRIPTION
Renamed `_jasminRegister()` into `_jasmineRegister()` to add missing missing "e".