### PR TITLE
chore: add dependabot version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+version: 2
+updates:
+    - package-ecosystem: 'npm'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'thursday'
+          time: '09:00'
+          timezone: 'America/Los_Angeles'
+      ignore:
+          # Base TS image (used for tsserver) must be update manually
+          # when updating the default node.js runtime
+          - dependency-name: '@tsconfig/*'
+          # TODO: remove this line once UTAM has been updated to latest version of wdio
+          - dependency-name: '@wdio/*'
+      open-pull-requests-limit: 10
+
+    - package-ecosystem: 'github-actions'
+      directory: '/'
+      schedule:
+          interval: 'weekly'
+          day: 'thursday'
+          time: '09:00'
+          timezone: 'America/Los_Angeles'

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,4 +1,4 @@
-.github/
+.github/**/*.md
 build/
 dist/
 node_modules/


### PR DESCRIPTION
This PR enables dependabot version updates so that dependabot will check for both npm and github-actions dependencies update every thursday at 9 AM PT