### PR TITLE
chore: bump pinned node version to node@16

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
         "wdio-utam-service": "^1.2.1"
     },
     "volta": {
-        "node": "14.15.4",
+        "node": "16.18.1",
         "yarn": "1.22.5"
     },
     "engines": {
-        "node": ">=14.15.4 <15"
+        "node": ">=14.15.4"
     },
     "workspaces": [
         "./",

--- a/utam-generator/package.json
+++ b/utam-generator/package.json
@@ -29,10 +29,9 @@
         "utam": "^1.1.0"
     },
     "volta": {
-        "node": "14.15.4",
-        "yarn": "1.22.5"
+        "extends": "../package.json"
     },
     "engines": {
-        "node": ">=14.15.4 <15"
+        "node": ">=14.15.4"
     }
 }

--- a/utam-preview/package.json
+++ b/utam-preview/package.json
@@ -32,10 +32,9 @@
         "utam": "^1.1.0"
     },
     "volta": {
-        "node": "14.15.4",
-        "yarn": "1.22.5"
+        "extends": "../package.json"
     },
     "engines": {
-        "node": ">=14.15.4 <15"
+        "node": ">=14.15.4"
     }
 }


### PR DESCRIPTION
This PR pin node.js to version 16 and also ensure volta uses it by default when switching to the workspace packages.