### PR TITLE
fix: update wdio jasmine options key name

### DIFF
--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -43,7 +43,7 @@ exports.config = {
     ],
     framework: 'jasmine',
     reporters: ['spec'],
-    jasmineNodeOpts: {
+    jasmineOpts: {
         // max execution time for a script, set to 5 min
         defaultTimeoutInterval: 1000 * 60 * 5,
         // Temporary workaround to get babel to work in wdio tests

--- a/wdio.conf.mobilebase.js
+++ b/wdio.conf.mobilebase.js
@@ -43,7 +43,7 @@ exports.mobileBaseConfig = {
     connectionRetryCount: 3,
     framework: 'jasmine',
     reporters: ['spec'],
-    jasmineNodeOpts: {
+    jasmineOpts: {
         // max execution time for a script, set to 5 min
         defaultTimeoutInterval: 1000 * 60 * 5,
         // Temporary workaround to get babel to work in wdio tests


### PR DESCRIPTION
This PR updates the WDIO configuration to use the property key name for jasmine options. The key name changed from v6 to v7 and we should update our configs to reflect the new config.

Closes #101 