### PR TITLE
chore: use utam json schema from schema store

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,8 +4,10 @@
     },
     "json.schemas": [
         {
-            "fileMatch": ["*.utam.json"],
-            "url": "https://utam.dev/schemas/v1/utam.json"
+            "fileMatch": [
+                "*.utam.json"
+            ],
+            "url": "https://json.schemastore.org/utam-page-object.json"
         }
     ]
 }


### PR DESCRIPTION
This PR updates the URL of the UTAM JSON schema from the UTAM Doc site to[ Schema store](https://json.schemastore.org/utam-page-object.json). 

We moved the JSON schema to the schema store and the old URL has been deprecated.