### PR TITLE
chore: bump tsconfig base from node16 to 18

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,8 @@
 {
-    "extends": "@tsconfig/node18/tsconfig.json",
+    "extends": [
+        "@tsconfig/node18/tsconfig.json",
+        "@tsconfig/strictest"
+    ],
     "include": [
         "force-app/test/**/*"
     ],
@@ -10,8 +13,6 @@
     ],
     "compilerOptions": {
         "noEmit": true,
-        "checkJs": true,
-        "strict": true,
         "types": [
             "node",
             "@wdio/globals/types",

--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,5 @@
 {
-    "extends": "@tsconfig/node16/tsconfig.json",
+    "extends": "@tsconfig/node18/tsconfig.json",
     "include": [
         "force-app/test/**/*"
     ],
@@ -12,10 +12,11 @@
         "noEmit": true,
         "checkJs": true,
         "strict": true,
-        "paths": {
-            "salesforce-pageobjects/*": [
-                "./node_modules/salesforce-pageobjects/dist/*"
-            ]
-        }
+        "types": [
+            "node",
+            "@wdio/globals/types",
+            "@wdio/jasmine-framework",
+            "wdio-utam-service"
+        ]
     }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
         "@salesforce/eslint-plugin-lightning": "^1.0.0",
         "@salesforce/sfdx-lwc-jest": "^3.0.1",
         "@tsconfig/node18": "^18.2.2",
+        "@tsconfig/strictest": "^2.0.2",
         "@types/jasmine": "5.1.2",
         "@wdio/appium-service": "^8.23.0",
         "@wdio/cli": "^8.23.0",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
         "@salesforce/eslint-config-lwc": "^3.5.2",
         "@salesforce/eslint-plugin-lightning": "^1.0.0",
         "@salesforce/sfdx-lwc-jest": "^3.0.1",
-        "@tsconfig/node16": "^1.0.4",
+        "@tsconfig/node18": "^18.2.2",
         "@types/jasmine": "5.1.2",
         "@wdio/appium-service": "^8.23.0",
         "@wdio/cli": "^8.23.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1890,10 +1890,10 @@
   resolved "https://registry.yarnpkg.com/@tootallnate/quickjs-emscripten/-/quickjs-emscripten-0.23.0.tgz#db4ecfd499a9765ab24002c3b696d02e6d32a12c"
   integrity sha512-C5Mc6rdnsaJDjO3UpGW/CQTHtCKaYlScZTly4JIu97Jxo/odCiH0ITnDXSJPTOrEKk/ycSZ0AOgTmkDtkOsvIA==
 
-"@tsconfig/node16@^1.0.4":
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
-  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
+"@tsconfig/node18@^18.2.2":
+  version "18.2.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node18/-/node18-18.2.2.tgz#81fb16ecff0d400b1cbadbf76713b50f331029ce"
+  integrity sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==
 
 "@types/babel__core@^7.1.14":
   version "7.20.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1895,6 +1895,11 @@
   resolved "https://registry.yarnpkg.com/@tsconfig/node18/-/node18-18.2.2.tgz#81fb16ecff0d400b1cbadbf76713b50f331029ce"
   integrity sha512-d6McJeGsuoRlwWZmVIeE8CUA27lu6jLjvv1JzqmpsytOYYbVi1tHZEnwCNVOXnj4pyLvneZlFlpXUK+X9wBWyw==
 
+"@tsconfig/strictest@^2.0.2":
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/@tsconfig/strictest/-/strictest-2.0.2.tgz#97167bf99c03d0a010d9946ae8a702c4f62e2783"
+  integrity sha512-jt4jIsWKvUvuY6adJnQJlb/UR7DdjC8CjHI/OaSQruj2yX9/K6+KOvDt/vD6udqos/FUk5Op66CvYT7TBLYO5Q==
+
 "@types/babel__core@^7.1.14":
   version "7.20.0"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.20.0.tgz#61bc5a4cae505ce98e1e36c5445e4bee060d8891"


### PR DESCRIPTION
This PR fixes the TypeScript configuration used to TypeCheck our test using TSServer in the IDE. The configuration is mostly used for autocompletion and providing feedback while authoring tests in the repository. This PR fixes the following:

1. We are compliant with TypeScript module resolution algorithm, we don't need the path hack anymore
2. The base tsconfig image is updated from node16 to node18
3. We add the types for the library used so that utam is recognized and available as a global variable