### PR TITLE
fix(yarn): update install command for ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
             - run:
                   name: Install dependencies and build
                   command: |
-                      YARN_CACHE_FOLDER=~/.cache/yarn yarn install immutable
+                      YARN_CACHE_FOLDER=~/.cache/yarn yarn install --immutable
                       yarn build
             - run:
                   name: Check missing file headers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,6 +63,8 @@ jobs:
     build:
         executor: node
         steps:
+            - run:
+                command: corepack enable
             - checkout
             - restore_yarn_cache
             - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,13 +20,6 @@ deploy_filters: &deploy_filters
 # Jobs definition
 version: 2.1
 
-# Custom executors definition
-executors:
-    node:
-        working_directory: ~/utam-js-recipes
-        docker:
-            - image: cimg/node:18.18
-
 # Custom commands definition
 commands:
     # Setup
@@ -58,31 +51,28 @@ commands:
             - attach_workspace:
                   at: ~/utam-js-recipes
 
+# Orb for yarn
+orbs:
+  node: circleci/node@5.2.0
+
 # Jobs definition
 jobs:
     build:
-        executor: node
+        executor:
+            - name: node/default
+            - tag: '16'
         steps:
-            - run:
-                command: corepack enable
             - checkout
-            - restore_yarn_cache
-            - run:
-                  name: Install dependencies and build
-                  command: |
-                      YARN_CACHE_FOLDER=~/.cache/yarn yarn install --immutable
-                      yarn build
+            - install-packages:
+                check-cache: always
+                pkg-manager: yarn-berry
+                with-cache: false
             - run:
                   name: Check missing file headers
                   command: node ./scripts/check-license-headers.js
             - run:
                   name: Check formatting
                   command: yarn prettier --check 'force-app/**/*.{js,ts,json,md}'
-            # - run:
-            #     name: Run linter
-            #     command: yarn lint
-            - save_yarn_cache
-            - save_workspace
 
 # Workflows definition
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,22 +57,22 @@ orbs:
 
 # Jobs definition
 jobs:
-build:
-  executor:
-    name: node/default
-    tag: '18.18'
-  steps:
-    - checkout
-    - node/install-packages:
-        check-cache: always
-        pkg-manager: yarn-berry
-        with-cache: false
-    - run:
-        name: Check missing file headers
-        command: node ./scripts/check-license-headers.js
-    - run:
-        name: Check formatting
-        command: yarn prettier --check 'force-app/**/*.{js,ts,json,md}'
+  build:
+    executor:
+      name: node/default
+      tag: '18.18'
+    steps:
+      - checkout
+      - node/install-packages:
+          check-cache: always
+          pkg-manager: yarn-berry
+          with-cache: false
+      - run:
+          name: Check missing file headers
+          command: node ./scripts/check-license-headers.js
+      - run:
+          name: Check formatting
+          command: yarn prettier --check 'force-app/**/*.{js,ts,json,md}'
 
 # Workflows definition
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,10 +64,11 @@ jobs:
       resource_class: medium
     steps:
       - checkout
-      - node/install:
-          install-yarn: true
-          yarn-version: 4.0.2
-          node-version: '18.18'
+      - run:
+          name: Yarn Set Version Stable
+          command: |
+            npm install -g yarn || echo "Yarn may have already been installed."
+            yarn set version 4.0.2
       - node/install-packages:
           check-cache: always
           pkg-manager: yarn-berry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -61,8 +61,13 @@ jobs:
     executor:
       name: node/default
       tag: '18.18'
+      resource_class: medium
     steps:
       - checkout
+      - node/install:
+          install-yarn: true
+          yarn-version: 4.0.2
+          node-version: '18.18'
       - node/install-packages:
           check-cache: always
           pkg-manager: yarn-berry

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
             - run:
                   name: Install dependencies and build
                   command: |
-                      yarn install --frozen-lockfile --cache-folder ~/.cache/yarn
+                      YARN_CACHE_FOLDER=~/.cache/yarn yarn install
                       yarn build
             - run:
                   name: Check missing file headers

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,7 +59,8 @@ orbs:
 jobs:
     build:
         executor:
-            - name: node/default-16
+            - name: node/default
+            - tag: '18.18'
         steps:
             - checkout
             - node/install-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,22 +57,22 @@ orbs:
 
 # Jobs definition
 jobs:
-    build:
-        executor:
-            - name: node/default
-            - tag: '18.18'
-        steps:
-            - checkout
-            - node/install-packages:
-                  check-cache: always
-                  pkg-manager: yarn-berry
-                  with-cache: false
-            - run:
-                  name: Check missing file headers
-                  command: node ./scripts/check-license-headers.js
-            - run:
-                  name: Check formatting
-                  command: yarn prettier --check 'force-app/**/*.{js,ts,json,md}'
+build:
+  executor:
+    name: node/default
+    tag: '18.18'
+  steps:
+    - checkout
+    - node/install-packages:
+        check-cache: always
+        pkg-manager: yarn-berry
+        with-cache: false
+    - run:
+        name: Check missing file headers
+        command: node ./scripts/check-license-headers.js
+    - run:
+        name: Check formatting
+        command: yarn prettier --check 'force-app/**/*.{js,ts,json,md}'
 
 # Workflows definition
 workflows:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,9 +64,9 @@ jobs:
         steps:
             - checkout
             - node/install-packages:
-                check-cache: always
-                pkg-manager: yarn-berry
-                with-cache: false
+                  check-cache: always
+                  pkg-manager: yarn-berry
+                  with-cache: false
             - run:
                   name: Check missing file headers
                   command: node ./scripts/check-license-headers.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -63,7 +63,7 @@ jobs:
             - tag: '16'
         steps:
             - checkout
-            - install-packages:
+            - node/install-packages:
                 check-cache: always
                 pkg-manager: yarn-berry
                 with-cache: false

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,7 +67,6 @@ jobs:
       - run:
           name: Yarn Set Version Stable
           command: |
-            npm install -g yarn || echo "Yarn may have already been installed."
             yarn set version 4.0.2
       - node/install-packages:
           check-cache: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,6 +57,9 @@ jobs:
           pkg-manager: yarn-berry
           cache-path: '~/.yarn/cache'
       - run:
+          name: Build
+          command: yarn build
+      - run:
           name: Check missing file headers
           command: node ./scripts/check-license-headers.js
       - run:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,55 +1,39 @@
 # Shared config
 ignore_forks: &ignore_forks
-    branches:
-        # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-        ignore: /pull\/[0-9]+/
+  branches:
+    # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+    ignore: /pull\/[0-9]+/
 
 only_forks: &only_forks
-    branches:
-        # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
-        only: /pull\/[0-9]+/
+  branches:
+    # Forked pull requests have CIRCLE_BRANCH set to pull/XXX
+    only: /pull\/[0-9]+/
 
 deploy_filters: &deploy_filters
-    filters:
-        branches:
-            ignore: /.*/
-        tags:
-            # Trigger on tags that begin with `v`
-            only: /^v.*/
+  filters:
+    branches:
+      ignore: /.*/
+    tags:
+      # Trigger on tags that begin with `v`
+      only: /^v.*/
 
 # Jobs definition
 version: 2.1
 
 # Custom commands definition
 commands:
-    # Setup
-    restore_yarn_cache:
-        description: Restore Yarn cache from previous build
-        steps:
-            - restore_cache:
-                  keys:
-                      - yarn-packages-v1-{{ checksum "yarn.lock" }}
+  save_workspace:
+    description: Save current workspace
+    steps:
+      - persist_to_workspace:
+          root: .
+          paths: .
 
-    save_yarn_cache:
-        description: Save Yarn cache for future builds
-        steps:
-            - save_cache:
-                  key: yarn-packages-v1-{{ checksum "yarn.lock" }}
-                  paths:
-                      - ~/.cache/yarn
-
-    save_workspace:
-        description: Save current workspace
-        steps:
-            - persist_to_workspace:
-                  root: .
-                  paths: .
-
-    load_workspace:
-        description: Load workspace
-        steps:
-            - attach_workspace:
-                  at: ~/utam-js-recipes
+  load_workspace:
+    description: Load workspace
+    steps:
+      - attach_workspace:
+          at: ~/utam-js-recipes
 
 # Orb for yarn
 orbs:
@@ -71,7 +55,6 @@ jobs:
       - node/install-packages:
           check-cache: always
           pkg-manager: yarn-berry
-          with-cache: false
       - run:
           name: Check missing file headers
           command: node ./scripts/check-license-headers.js
@@ -81,7 +64,7 @@ jobs:
 
 # Workflows definition
 workflows:
-    version: 2
-    build:
-        jobs:
-            - build
+  version: 2
+  build:
+    jobs:
+      - build

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -59,8 +59,7 @@ orbs:
 jobs:
     build:
         executor:
-            - name: node/default
-            - tag: '16'
+            - name: node/default-16
         steps:
             - checkout
             - node/install-packages:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,6 +55,7 @@ jobs:
       - node/install-packages:
           check-cache: always
           pkg-manager: yarn-berry
+          cache-path: '~/.yarn/cache'
       - run:
           name: Check missing file headers
           command: node ./scripts/check-license-headers.js

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -68,7 +68,7 @@ jobs:
             - run:
                   name: Install dependencies and build
                   command: |
-                      YARN_CACHE_FOLDER=~/.cache/yarn yarn install
+                      YARN_CACHE_FOLDER=~/.cache/yarn yarn install immutable
                       yarn build
             - run:
                   name: Check missing file headers


### PR DESCRIPTION
[!IMPORTANT]
When reviewing, disable whitespace. The .yaml file was not using the conventional two spaces per level, so I fixed it. It makes the review very noisy though.

Update the CI configuration to use modern yarn.

I've switched us to using the `node` orb instead of just the `cimg/node` Docker image. We end up using the same  Docker image, just a different route to get there. The orb comes with a `node/install-packages` helper that wraps the install process and handles caching for us. Therefore, I removed the caching code.

I also lowered the `resource_class` of the run to `medium`, since we barely do anything in it. 4GB RAM should be plenty.